### PR TITLE
Add dual workbook upload with discrepancy highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A modern web application that processes multi-sheet Excel files to create format
 - **Two-Step Processing**:
   - **Step 1**: Creates formatted report with headers A-V and applies styling
   - **Step 2**: Enriches data using lookup tables and business rules
+- **Workbook Comparison**: Optionally upload an existing formatted workbook to highlight deltas, append new deals, and list missing entries
 - **Dashboard Metrics**: Displays total deals, volume, and product distribution
 - **Perfect Formatting**: Bold headers, yellow month cells, column borders, and proper alignment
 - **Download**: Exports final Excel workbook with professional formatting

--- a/index.html
+++ b/index.html
@@ -47,22 +47,49 @@
                     <p>Upload your petroleum trading data for analysis</p>
                 </div>
                 <div class="upload-area">
-                    <input type="file" id="fileInput" accept=".xlsx,.xls" style="display: none;">
-                    <label for="fileInput" class="upload-zone">
-                        <div class="upload-icon">
-                            <svg width="48" height="48" viewBox="0 0 24 24" fill="currentColor">
-                                <path d="M14,2H6A2,2 0 0,0 4,4V20A2,2 0 0,0 6,22H18A2,2 0 0,0 20,20V8L14,2M18,20H6V4H13V9H18V20Z" />
-                            </svg>
+                    <div class="upload-grid">
+                        <div class="upload-group">
+                            <span class="upload-label">Raw data workbook</span>
+                            <input type="file" id="rawFileInput" accept=".xlsx,.xls" style="display: none;">
+                            <label for="rawFileInput" class="upload-zone">
+                                <div class="upload-icon">
+                                    <svg width="48" height="48" viewBox="0 0 24 24" fill="currentColor">
+                                        <path d="M14,2H6A2,2 0 0,0 4,4V20A2,2 0 0,0 6,22H18A2,2 0 0,0 20,20V8L14,2M18,20H6V4H13V9H18V20Z" />
+                                    </svg>
+                                </div>
+                                <div class="upload-text">
+                                    <span class="upload-title">Upload raw Excel</span>
+                                    <span class="upload-subtitle">3-sheet source workbook</span>
+                                </div>
+                            </label>
+                            <div class="file-selected" id="rawFileInfo" style="display: none;">
+                                <div class="file-details">
+                                    <span id="rawFileName"></span>
+                                    <button id="clearRawFile" class="clear-btn" type="button">×</button>
+                                </div>
+                            </div>
                         </div>
-                        <div class="upload-text">
-                            <span class="upload-title">Choose Excel File</span>
-                            <span class="upload-subtitle">Drag & drop or click to browse</span>
-                        </div>
-                    </label>
-                    <div class="file-selected" id="fileInfo" style="display: none;">
-                        <div class="file-details">
-                            <span id="fileName"></span>
-                            <button id="clearFile" class="clear-btn">×</button>
+
+                        <div class="upload-group">
+                            <span class="upload-label">Existing formatted workbook <span class="optional-tag">(optional)</span></span>
+                            <input type="file" id="formattedFileInput" accept=".xlsx,.xls" style="display: none;">
+                            <label for="formattedFileInput" class="upload-zone">
+                                <div class="upload-icon">
+                                    <svg width="48" height="48" viewBox="0 0 24 24" fill="currentColor">
+                                        <path d="M14,2H6A2,2 0 0,0 4,4V20A2,2 0 0,0 6,22H18A2,2 0 0,0 20,20V8L14,2M18,20H6V4H13V9H18V20Z" />
+                                    </svg>
+                                </div>
+                                <div class="upload-text">
+                                    <span class="upload-title">Upload formatted Excel</span>
+                                    <span class="upload-subtitle">Compare & highlight differences</span>
+                                </div>
+                            </label>
+                            <div class="file-selected" id="formattedFileInfo" style="display: none;">
+                                <div class="file-details">
+                                    <span id="formattedFileName"></span>
+                                    <button id="clearFormattedFile" class="clear-btn" type="button">×</button>
+                                </div>
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/styles.css
+++ b/styles.css
@@ -224,6 +224,34 @@ body, .dashboard, .dashboard-main, .dashboard-header {
     margin-bottom: var(--space-xl);
 }
 
+.upload-grid {
+    display: grid;
+    gap: var(--space-lg);
+}
+
+@media (min-width: 900px) {
+    .upload-grid {
+        grid-template-columns: repeat(2, 1fr);
+    }
+}
+
+.upload-group {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-sm);
+}
+
+.upload-label {
+    font-weight: 600;
+    color: var(--gray-700);
+}
+
+.optional-tag {
+    font-weight: 500;
+    color: var(--gray-500);
+    font-size: 0.85rem;
+}
+
 .upload-zone {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
## Summary
- allow selecting both the raw workbook and an optional formatted workbook from the dashboard
- extend the FastAPI processor to compare against an existing workbook, highlight changes, and list deals missing from the raw data
- style the dual upload layout and document the new comparison capability

## Testing
- python -m compileall server.py

------
https://chatgpt.com/codex/tasks/task_e_68ca8533b1488329958ff6f3c337e5ac